### PR TITLE
Catching and logging exceptions from cron jobs

### DIFF
--- a/django_crontab/management/commands/crontab.py
+++ b/django_crontab/management/commands/crontab.py
@@ -6,6 +6,9 @@ from django_crontab.app_settings import CRONTAB_EXECUTABLE, CRONJOBS, \
 import os
 import tempfile
 
+import logging
+logger = logging.getLogger(__name__)
+
 class Command(BaseCommand):
     args = '<add|remove>'
     help = 'run this command to add or remove the jobs defined in CRONJOBS setting from/to crontab'
@@ -96,5 +99,8 @@ class Command(BaseCommand):
                 module_path, function_name = function.rsplit('.', 1)
                 module = import_module(module_path)
                 func = getattr(module, function_name)
-                func()
+                try:
+                    func()
+                except:
+                    logger.exception('Failed to complete cronjob at %s', function)
 


### PR DESCRIPTION
At the moment, the errors in the executed cron jobs seem to get lost and not caught by Django loggers.. this should fix that. Unless I'm missing something, but really couldn't spot what.

PS: apologies for the weird commits etc.. github nub :x
