### PR TITLE
Added readme example of the  CRONTAB_COMMAND_SUFFIX usage.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ CRONTAB_COMMAND_PREFIX
 CRONTAB_COMMAND_SUFFIX
   - something you wanne do after each job was executed.
   - default: '' (empty string)
-  - example: (do you know a good example?)
+  - example: '2>&1'
 
 CRONTAB_COMMENT
   - used for marking the added contab-lines for removing, default value includes project name to distinguish multiple projects on the same host and user


### PR DESCRIPTION
Example, if you want to redirect stderr to stdout, so you can see errors in your scripts logs.