### PR TITLE
Sanitize comand line executable.

### DIFF
--- a/django_crontab/app_settings.py
+++ b/django_crontab/app_settings.py
@@ -45,3 +45,7 @@ class Settings():
         self.COMMAND_SUFFIX = getattr(settings, 'CRONTAB_COMMAND_SUFFIX', '')
 
         self.LOCK_JOBS = getattr(settings, 'CRONTAB_LOCK_JOBS', False)
+        
+        # Sanitizes path 
+        self.PYTHON_EXECUTABLE = shlex.quote(self.PYTHON_EXECUTABLE)
+        self.DJANGO_MANAGE_PATH = shlex.quote(self.DJANGO_MANAGE_PATH)


### PR DESCRIPTION
I had some problem when I execute cron task that it was located in path with white space. For example:
```
*/2 * * * * /david/folder/sub directory/venv/bin/python3  /david/folder/sub directory/manage.py crontab run d2d1c10b3ad2d1924dd9aaaca2535efb # django-cronjobs for sub directory
```
I propose add the next two line with the local library shlex.quote(). This function sanitize the path in other to avoid problems when the system interpreted it.  
```
*/2 * * * * '/david/folder/sub directory/venv/bin/python3'  '/david/folder/sub directory/manage.py' crontab run d2d1c10b3ad2d1924dd9aaaca2535efb # django-cronjobs for sub directory
```
 I have tested it (Linux Ubuntu 18.04) but i don't know if it could suppose another bugs.

Thank you for your work.